### PR TITLE
Fork @flighter/a1-notation into @segment/a1-notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This library is for working with A1 notations such as "A1" or "A1:B2". The libra
 
 ### Install
 ```
-npm i @flighter/a1-notation -d
+npm i @segment/a1-notation -d
 ```
 Or
 ```
-yarn add @flighter/a1-notation
+yarn add @segment/a1-notation
 ```
 
 ### Download
@@ -32,9 +32,9 @@ yarn add @flighter/a1-notation
 
 ## Initialization
 ```js
-import A1 from '@flighter/a1-notation';
+import A1 from '@segment/a1-notation';
 // or
-const A1 = require('@flighter/a1-notation');
+const A1 = require('@segment/a1-notation');
 ```
 
 ## API

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@flighter/a1-notation",
+  "name": "@segment/a1-notation",
   "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@flighter/a1-notation",
+      "name": "@segment/a1-notation",
       "version": "2.1.2",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,11 @@
 {
-  "completed": true,
-  "projectName": "A1",
-  "projectContext": "undefined",
   "description": "Work with A1 notation like \"A1\" or \"A1:B2\"",
-  "name": "@flighter/a1-notation",
+  "name": "@segment/a1-notation",
   "version": "2.1.2",
   "main": "./dist/index.umd.js",
   "types": "./dist/index.d.ts",
   "author": "FLighter",
   "license": "MIT",
-  "repository": "github:FLighter7/a1-notation",
   "keywords": [
     "A1",
     "spreadsheet",


### PR DESCRIPTION
We're forking an external package used for a1-notation data manipulation into @segment's workspace so we have better control of future changes and additions.